### PR TITLE
Fix: Code of conduct link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Reading and following these guidelines will help us make the contribution proces
 
 ## Code of Conduct
 
-We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/divanov11/mumble/master/CODE_OF_CONDUCT.md).
+We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/divanov11/Mumble/blob/master/CODE_OF_CONDUCT.md).
 
 ## Getting Started
 


### PR DESCRIPTION
This is the changed line
```diff
- We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/divanov11/mumble/master/CODE_OF_CONDUCT.md).
+ We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/divanov11/Mumble/blob/master/CODE_OF_CONDUCT.md).
```