### PR TITLE
Fixed alignment in discussion page and feed

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -164,6 +164,11 @@ body{
   resize: none;
 }
 
+textarea:focus-within {
+  outline: none;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 0px 3px;
+}
+
 
 #post-btn-wrapper{
   display: flex;
@@ -207,6 +212,7 @@ body{
 
 .contributor-preview{
   display: flex;
+  align-items: center;
 }
 
 .contributor-preview a{
@@ -300,7 +306,6 @@ body{
   min-width: 25px;
   padding: 5px;
   margin-right: 10px;
- 
 }
 
 .snippet-text{
@@ -316,6 +321,9 @@ body{
   align-items: center;
 }
 
+.replying-to-text {
+  margin-left: 65px;
+}
 
 
 .post-meta{
@@ -327,7 +335,7 @@ body{
   display: flex;
   padding-bottom: 20px;
   border-bottom: 1px solid #EAEDF3;
-  
+  align-items: center;
 }
 
 .post-votes{

--- a/frontend/src/Components/Feed.js
+++ b/frontend/src/Components/Feed.js
@@ -54,7 +54,7 @@ function Feed({ posts }) {
                                             <p className="post-meta">{comment.created}</p>
 
                                         </div>
-                                        <i><small>Replying to  {comment.reply_at.map(user => (<span>- @{user.username}</span>))}</small></i>
+                                        <i class="replying-to-text"><small>Replying to  {comment.reply_at.map(user => (<span>- @{user.username}</span>))}</small></i>
                                         <div className="post-contents">
                                             <div className="post-votes">
                                                 <i className="fas fa-arrow-alt-up vote-icon up-arrow"></i>

--- a/frontend/src/Css/Discussion.css
+++ b/frontend/src/Css/Discussion.css
@@ -11,7 +11,7 @@
 .question-wrapper{
     display: grid;
     grid-template-columns: 1fr 10fr;
-    margin-bottom: 10px;
+    margin-bottom: 20px;
 }
 
 .discussion-headline{
@@ -24,26 +24,43 @@
     font-style: italic;
 }
 .question-sidebar {
+    margin-right: 10px;
     justify-self: center;
     display: flex;
     flex-direction: column;
     align-items: center;
 }
+
+.question-sidebar .user-thumbnail {
+    margin-right: 0;
+}
+
 .big-vote-count{
-    font-size: 24px;
+    font-size: 16px;
     font-weight: 900;
     color: #5eba7d;
 }
 
 .big-up-arrow{
-    font-size: 36px;
+    font-size: 18px;
 }
 
 .big-down-arrow{
-    font-size: 36px;
+    font-size: 18px;
 }
+
 .voting-widget {
+    margin-top: 15px;
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+.question-body {
+    margin-bottom: 20px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    border-bottom: 1px solid #EAEDF3;
 }

--- a/frontend/src/Pages/Discussion.js
+++ b/frontend/src/Pages/Discussion.js
@@ -49,15 +49,15 @@ function Discussion({ match }) {
 
                                         <div className="question-sidebar">
                                             <img alt="img-description" className="user-thumbnail user-thumbnail-sm" src={answer.user.profile_pic} />
-                                            <div className="custom-spacer"></div>
+                                            {/* <div className="custom-spacer"></div> */}
                                             <VotingWidget voteRatio={answer.vote_ratio}/>
                                         </div>
                                         <div className="question-body">
                                             <Link to={`/profile/${answer.user.username}`}><h6>{answer.user.name} <small><i> @{answer.user.username}</i></small></h6>
                                             </Link>
                                             <p>{answer.content}</p>
-                                            <div className="custom-spacer"></div>
-                                            <div className="line-break"></div>
+                                            {/* <div className="custom-spacer"></div> */}
+                                            {/* <div className="line-break"></div> */}
                                         </div>
                                     </div>
                                 ))}


### PR DESCRIPTION
### 1. Fixed alignment issues on feeds page
#### Before:
![home-align](https://user-images.githubusercontent.com/54238597/113145890-a0ed2d00-924c-11eb-95cf-5d3618fe2df4.png)

#### After:

![new-home-align](https://user-images.githubusercontent.com/54238597/113146037-d1cd6200-924c-11eb-9cac-123d19e15c76.png)


### 2. Fixed similar alignment issue(similar to above image) on discussion page also reduced voting arrow size, as bigger size was affecting the alignment
### 3. Textarea on feeds has outline on focus, removed that outline and add box-shadow to make visual difference on focus
### 4. Center align the names inside Top Contributors card on feeds(center align looks good)

Any Feedback?