### PR TITLE
Fix Google font GET Error

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -5,7 +5,7 @@
 
 /* Fonts */
 
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Poppins,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400&family=Poppins:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap');
 
 /* Base Styles */
 @import url('./common/_variables.css');


### PR DESCRIPTION
Fix Google font GET Error due to missing part in the font link

![Screenshot from 2021-04-03 23-45-10](https://user-images.githubusercontent.com/6501582/113492360-166c2e00-94d7-11eb-97d8-055bdf2a9a89.png)
