### PR TITLE
fixed voting widget up and down arrow hover colors

### DIFF
--- a/frontend/src/styles/components/Feed.css
+++ b/frontend/src/styles/components/Feed.css
@@ -85,12 +85,14 @@
 }
 
 .up-arrow:hover,
-.up-arrow.active {
+.up-arrow.active,
+.fa-chevron-up:hover:before {
   color: var(--color-success);
 }
 
 .down-arrow:hover,
-.down-arrow.active {
+.down-arrow.active,
+.fa-chevron-down:hover:before {
   color: var(--color-error);
 }
 


### PR DESCRIPTION
This pull request resolves Issue #172 with the up and down arrow colors not appearing.