### PR TITLE
The post not found page follows now the STYLE_GUIDE.md

### DIFF
--- a/frontend/src/styles/components/SearchByUsersAndPostList.css
+++ b/frontend/src/styles/components/SearchByUsersAndPostList.css
@@ -1,5 +1,5 @@
 .not-found h2 {
-  color: #73af8d;
+  color: var(--color-text);
   font-size: 6rem;
 }
 


### PR DESCRIPTION
## Well detailed description of the change :

     I worked on the post not found page by changing the h2 color to the text-color var


## Context of the change :

     The h2 element in Post not found page wasn't following the STYLE_GUIDE.md
     That's why i fixed that 
 

## Type of change :

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Preview (Screenshots) :

Before (light mode) :

![image](https://user-images.githubusercontent.com/72341453/115246877-ce274f80-a115-11eb-95e4-f1f32a46363d.png)

Before (dark mode)  :

![image](https://user-images.githubusercontent.com/72341453/115246113-20b43c00-a115-11eb-88df-7bdf8c89e0b1.png)

Preview of what i have done (light mode) :

![image](https://user-images.githubusercontent.com/72341453/115247140-0dee3700-a116-11eb-9061-0e4fdfe76dcf.png)

Preview of what i have done (dark mode) :

![image](https://user-images.githubusercontent.com/72341453/115247202-1e9ead00-a116-11eb-889a-1b2e5e64c663.png)


## Checklist:

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the **STYLE_GUIDE** of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
