### PR TITLE
Adding back search page classes to fix layout styling

### DIFF
--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -25,17 +25,19 @@ const SearchPage = () => {
 
   return (
     <div className="container three-column-layout three-column-layout__condense">
-      <div></div>
+      <section className="three-column-layout__left-column"></section>
 
-      <div>
+      <section>
         {category === CATEGORY_USERS && <SearchByUsersList />}
         {category === CATEGORY_POSTS && <SearchByPostsList />}
         {category === CATEGORY_ARTICLES && <SearchByArticlesList articles={articles} />}
         {category === CATEGORY_SKILLS && <SearchBySkillsList skills={skills} />}
         {category === CATEGORY_INTERESTS && <SearchByInterestsList interests={interests} />}
-      </div>
+      </section>
 
-      <SearchByPanel category={category} setCategory={setCategory} />
+      <section className="three-column-layout__right-column">
+        <SearchByPanel category={category} setCategory={setCategory} />
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
Bug:
The search page currently looks like this:

![Screen Shot 2021-05-12 at 9 36 50 PM](https://user-images.githubusercontent.com/1868782/118065002-2a267200-b36a-11eb-92a1-a76f350537cc.png)


Fix:
Adding layout classes:

![Screen Shot 2021-05-12 at 9 37 15 PM](https://user-images.githubusercontent.com/1868782/118065023-3a3e5180-b36a-11eb-85e5-944f7ddef548.png)
