### PR TITLE
#407 - hide discussions in UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start:local": "REACT_APP_API_ENDPOINT=http://127.0.0.1:8000 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,13 +15,11 @@ import { RestoreScroll } from './components';
 import { getUnreadNotifications } from './actions/notificationsActions';
 import {
   HomePage,
-  DiscussionPage,
   ArticlePage,
   ProfilePage,
   UserSettingsPage,
   SearchPage,
   CreateArticlePage,
-  CreateDiscussionPage,
   NotificationsPage,
   LoginSignupPage,
   Error404Page,
@@ -80,12 +78,10 @@ const App = () => {
           <Switch>
             <PrivateRoute exact path="/" component={HomePage} />
             <PrivateRoute exact path="/settings" component={UserSettingsPage} />
-            <PrivateRoute exact path="/create-discussion" component={CreateDiscussionPage} />
             <PrivateRoute exact path="/create-article" component={CreateArticlePage} />
             <Route exact path="/:parameter(login|signup)" component={LoginSignupPage} />
             <Route exact path="/profile/:username" component={ProfilePage} />
             <Route exact path="/notifications" component={NotificationsPage} />
-            <Route exact path="/discussion/:slug" component={DiscussionPage} />
             <Route exact path="/article/:slug" component={ArticlePage} />
             <Route exact path="/search" component={SearchPage} />
             <Route exact path="/articles" component={ArticlesPage} />

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -8,7 +8,6 @@ const menu = [
   { title: 'Inbox', icon: 'inbox', path: '/inbox', disabled: true },
   { title: 'Contributors', icon: 'users', path: '/search' },
   { title: 'Articles', icon: 'file', path: '/articles' },
-  { title: 'Discussions', icon: 'book-reader', path: '/discussions', disabled: true },
   { title: 'Topics', icon: 'tags', path: '/topics', disabled: true },
   { title: 'Settings', icon: 'tools', path: '/settings' },
 ];

--- a/frontend/src/pages/ArticlesPage.js
+++ b/frontend/src/pages/ArticlesPage.js
@@ -51,13 +51,15 @@ const ArticlesPage = () => {
         ))}
 
         <div>
-          <Button
-            size="lg"
-            disabled={!data?.next || loading}
-            onClick={handleLoadMore}
-            text={!loading ? 'Load More' : 'Loading...'}
-            iconName={loading && 'spinner fa-spin'}
-          />
+          {data.next && (
+            <Button
+              size="lg"
+              disabled={!data?.next || loading}
+              onClick={handleLoadMore}
+              text={!loading ? 'Load More' : 'Loading...'}
+              iconName={loading && 'spinner fa-spin'}
+            />
+          )}
         </div>
       </section>
 

--- a/frontend/src/pages/CreateDiscussionPage.js
+++ b/frontend/src/pages/CreateDiscussionPage.js
@@ -4,8 +4,7 @@ import { useHistory, Prompt } from 'react-router-dom';
 import '../styles/components/CreateDiscussionPage.css';
 
 import { Button } from '../common';
-import { DiscussionsCard, Page } from '../components';
-import { discussions } from '../data';
+import { Page } from '../components';
 
 const CreateDiscussionPage = () => {
   const history = useHistory();
@@ -81,9 +80,7 @@ const CreateDiscussionPage = () => {
           </div>
         </div>
       </section>
-      <section>
-        <DiscussionsCard discussions={discussions} />
-      </section>
+      <section></section>
     </Page>
   );
 };

--- a/frontend/src/pages/DiscussionPage.js
+++ b/frontend/src/pages/DiscussionPage.js
@@ -4,12 +4,11 @@ import { Link } from 'react-router-dom';
 import '../styles/components/DiscussionPage.css';
 
 import { Avatar, VotingWidget } from '../common';
-import { Contributors, DiscussionsCard, Page } from '../components';
+import { Contributors, Page } from '../components';
 import { discussions } from '../data';
 
 const Discussion = ({ match }) => {
   let discussion = discussions.find((d) => d.slug === match.params.slug);
-  let relatedQuestions = discussions.filter((d) => d.slug !== match.params.slug);
 
   let [users, setUsers] = useState([]);
 
@@ -88,7 +87,6 @@ const Discussion = ({ match }) => {
       </section>
       <section id="right-sidebar">
         <Contributors users={users} />
-        <DiscussionsCard discussions={relatedQuestions} />
       </section>
     </Page>
   );

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -8,11 +8,10 @@ import {
   FeedCard,
   CreatePost,
   TopicTags,
-  DiscussionsCard,
   PostCardPlaceholder,
   Page,
 } from '../components';
-import { discussions, usersData } from '../data';
+import { usersData } from '../data';
 import { getPostsForDashboard } from '../actions/postActions';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -44,11 +43,6 @@ const HomePage = () => {
       <section>
         <Contributors />
         <TopicTags tags={user.interests} />
-        <DiscussionsCard discussions={discussions} />
-        {/* 
-        At some point I will add articles into rotation with disccssions. This will be in one card -- Dennis Ivy
-        <ArticlesCard articles={articles} /> 
-        */}
       </section>
     </Page>
   );


### PR DESCRIPTION
### Well detailed description of the change :

#407

This PR hides the different places in the application we display `discussion` related components since Dennis want's the project to maybe hold off on discussions for right now.

#

### Context of the change :

Watch the video Dennis created: https://youtu.be/gg-ENAz3zL0
 
#

### Type of change :

<!-- You should choice 1 option -->

<!-- add a x in [ ] if true !-->

<!-- Delete options that aren't revelant!-->


- [ ] Bug fix

- [x] New feature

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Checklist:

<!-- Check your work !-->

<!-- add a x in [] if done !-->

<!-- let things that you didn't do !-->

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the **STYLE_GUIDE** of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed.

