### PR TITLE
fix up/downvoting issue (#428)

### DIFF
--- a/frontend/src/actions/postActions.js
+++ b/frontend/src/actions/postActions.js
@@ -140,14 +140,16 @@ export const getPostComments = (setComments, postId) => async (dispatch, getStat
 };
 
 export const modifyVote = (voteData) => async (dispatch, getState) => {
+  const remumbledPost = voteData.remumbled_post;
   try {
     dispatch({ type: POST_VOTE_REQUEST });
 
     const mumble = await postsService.modifyVote(voteData);
+    if (remumbledPost) remumbledPost.original_mumble = mumble;
 
     dispatch({
       type: POST_VOTE_SUCCESS,
-      payload: mumble,
+      payload: remumbledPost || mumble,
     });
   } catch (error) {
     dispatch(createActionPayload(POST_VOTE_FAIL, error));

--- a/frontend/src/common/VotingWidget.js
+++ b/frontend/src/common/VotingWidget.js
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 
 import { modifyVote } from '../actions/postActions';
 
-const VotingWidget = ({ votes, postId, postUsername, upVoters, downVoters, authUserId }) => {
+const VotingWidget = ({ votes, postId, postUsername, upVoters, downVoters, authUserId, remumbledPost }) => {
   const dispatch = useDispatch();
 
   const isUpVoted = upVoters.find((vote) => vote.id === authUserId);
@@ -14,7 +14,7 @@ const VotingWidget = ({ votes, postId, postUsername, upVoters, downVoters, authU
     <div className="post-votes">
       <i
         onClick={() =>
-          dispatch(modifyVote({ post_id: postId, value: 'upvote', post_username: postUsername }))
+          dispatch(modifyVote({ post_id: remumbledPost?.original_mumble.id || postId, value: 'upvote', post_username: postUsername, remumbled_post: remumbledPost }))
         }
         className={`${isUpVoted ? 'fas' : 'far'} fa-caret-up vote-icon up-arrow`}
       ></i>
@@ -29,7 +29,7 @@ const VotingWidget = ({ votes, postId, postUsername, upVoters, downVoters, authU
 
       <i
         onClick={() =>
-          dispatch(modifyVote({ post_id: postId, value: 'downvote', post_username: postUsername }))
+          dispatch(modifyVote({ post_id: remumbledPost?.original_mumble.id || postId, value: 'downvote', post_username: postUsername, remumbled_post: remumbledPost }))
         }
         className={`${isDownVoted ? 'fas' : 'far'} fa-caret-down vote-icon down-arrow`}
       ></i>
@@ -38,7 +38,7 @@ const VotingWidget = ({ votes, postId, postUsername, upVoters, downVoters, authU
 };
 
 VotingWidget.propTypes = {
-  authUserId: PropTypes.string,
+  authUserId: PropTypes.number,
   downVoters: PropTypes.array,
   postId: PropTypes.string,
   postUsername: PropTypes.string,

--- a/frontend/src/components/PostCard.js
+++ b/frontend/src/components/PostCard.js
@@ -12,7 +12,7 @@ const PostCard = ({ post, ancestors, link, isComment = false, children, ...other
   let dispatch = useDispatch();
 
   let authUser = auth.user;
-  let authUserId = String(authUser.id);
+  let authUserId = authUser.id;
   let postId = String(post.id);
 
   let [comments, setComments] = useState([]);
@@ -21,6 +21,7 @@ const PostCard = ({ post, ancestors, link, isComment = false, children, ...other
 
   const { user, original_mumble } = post;
   let remumble;
+  let remumbledPost;
 
   if (original_mumble) {
     remumble = {
@@ -30,6 +31,7 @@ const PostCard = ({ post, ancestors, link, isComment = false, children, ...other
       originalMumbleId: original_mumble.id,
       originalUserId: original_mumble.user.user,
     };
+    remumbledPost = post;
     post = original_mumble;
   }
 
@@ -69,6 +71,7 @@ const PostCard = ({ post, ancestors, link, isComment = false, children, ...other
             upVoters={post.upVoters}
             downVoters={post.downVoters}
             authUserId={authUserId}
+            remumbledPost={remumbledPost}
           />
           <div className="post-body">
             {children}


### PR DESCRIPTION
### Well detailed description of the change :

- We can now up and downvoting all remumbled posts correctly. This was previously bugged for remumbled post because the request to /api/mumbles/vote/ was sent with the wrong post id and then dispatched with the wrong mumble object.

- The up and down arrow icons are now switching between the 2 icons type (fas, far) correctly when selected.

#

### Context of the change :

#428 
 
#

### Type of change :

- [x] Bug fix

#

### Preview (Screenshots) :

See previous gif in issue #428 and this one :
https://i.gyazo.com/c854a525106d614e35035e147f306c3b.mp4

#

### Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the **STYLE_GUIDE** of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed.

#

### Reviewers

@MidouWebDev,  @codyseibert