### PR TITLE
bug-fix: Hovering over icons in dark mode have color effect now

### DIFF
--- a/frontend/src/styles/common/_typography.css
+++ b/frontend/src/styles/common/_typography.css
@@ -61,7 +61,7 @@ a {
   font-weight: var(--font-medium);
 }
 
-.dark-theme i.fas,
-.dark-theme i.far {
-  color: var(--color-text) !important;
+.dark-theme .fas,
+.dark-theme .far {
+  color: var(--color-text);
 }


### PR DESCRIPTION
### Well detailed description of the change :

     I worked on the issue #434. 
     The PR includes changes in the `src/styles/common/_typography.css` file where the specificity of icon selectors in dark mode was changed.

#

### Context of the change :

     - Why is this change required ? -> This was required since in the production website, the color effect on icon hover was not responding for dark mode.

- Does it solve a problem ? (please link the issue)
 Yes the solution fixes the issue by changing the specificity. Link to issue - #434 

### Type of change 👍🏽 
- [x] Bug fix

- [ ] New feature

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#

### Preview (Screenshots) :

https://user-images.githubusercontent.com/53562523/120906435-fc85cd80-c676-11eb-9d84-44c9adf238d3.mp4

In the GIF, the color effect on icon hover is now working for both light and dark mode
#

### Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the **STYLE_GUIDE** of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed.

#

### Reviewers
@MidouWebDev @divanov11 